### PR TITLE
Fix capacity and waiting time bugs

### DIFF
--- a/Codes/Analytique_calcul_esperance.py
+++ b/Codes/Analytique_calcul_esperance.py
@@ -115,6 +115,6 @@ def calculEY(T,C,lamda,m2,p2,B):
     A1=calculEA(m2, p2)
     B1=calculdEA(lamda, T, m2, p2)
     #C1=calculallPi(T, C, m2, p2, B)
-    P1=((A1*C2-B1)/(A1-1)**2)*calculallPi(lamda,T, C, m2, p2, B)
-    P2=(A1/(A1-1))*calculallPi2(lamda,T, C, m2, p2, B)
-    return P1+P2
+    P1 = ((A1 * C2 - B1) / (A1 - 1) ** 2) * calculallPi(lamda, T, C, m2, p2, B)
+    P2 = (A1 / (A1 - 1)) * calculallPi2(lamda, T, C, m2, p2, B)
+    return P1 + P2

--- a/Codes/Simulation.py
+++ b/Codes/Simulation.py
@@ -257,7 +257,7 @@ def simulate_temps_poisson(N,lam_1,lam_2,m1,m2,p1,p2,C,pr1,pr2,slot_duration_ms)
                 L_temps_1.append(tps * slot_duration_ms)
                 #dic_del_1[(y1,y2,n)]=tps
                 dic_del_1[(y1,y2,n)]=tps * slot_duration_ms
-                dic_att_1[(y1,y2,n)]=calcul_attente(y1,C0)
+                dic_att_1[(y1,y2,n)]=calcul_attente(y1,C0, slot_duration_ms)
                 #dic_del_par_RB_1[(y1,y2,n)]=round(tps/y1,2)  
                 dic_del_par_RB_1[(y1,y2,n)] = round((tps * slot_duration_ms) / y1, 2)
         elif etat_Y2<=C2+C0: #système saturé
@@ -357,7 +357,7 @@ def calcul_C(scs_kHz):
     if scs_kHz == 15:
         RBs_per_slot = 52
     elif scs_kHz == 30:
-        RBs_per_slot = 24
+        RBs_per_slot = 27
     elif scs_kHz == 60:
         RBs_per_slot = 11
     else:


### PR DESCRIPTION
## Summary
- correct the RB count for 30 kHz SCS
- fix missing parameter when computing waiting time
- clean up analytic expectation script and ensure newline

## Testing
- `python -m py_compile Codes/Simulation.py Codes/Analytique_calcul_esperance.py`

------
https://chatgpt.com/codex/tasks/task_e_6840323471048322a78df0b21cd029a5